### PR TITLE
feat: 온보딩 개인특성페이지 기능 추가 구현

### DIFF
--- a/src/app/(auth)/onboarding/characteristic/food-types/page.tsx
+++ b/src/app/(auth)/onboarding/characteristic/food-types/page.tsx
@@ -9,9 +9,9 @@ import { useOnboardingStore } from "@/src/stores/onboarding-store";
 
 export default function FoodTypesPage() {
   const router = useRouter();
-  const { noPreferences, foodTypes, setFoodTypes } = useOnboardingStore();
+  const { foodTypes, setFoodTypes } = useOnboardingStore();
 
-  const canProceed = noPreferences || foodTypes.length > 0;
+  const canProceed = foodTypes.length > 0;
 
   const handleNext = () => {
     if (!canProceed) return;

--- a/src/app/(auth)/onboarding/characteristic/ingredients/page.tsx
+++ b/src/app/(auth)/onboarding/characteristic/ingredients/page.tsx
@@ -9,9 +9,9 @@ import { useOnboardingStore } from "@/src/stores/onboarding-store";
 
 export default function IngredientsPage() {
   const router = useRouter();
-  const { noPreferences, ingredients, setIngredients } = useOnboardingStore();
+  const { ingredients, setIngredients } = useOnboardingStore();
 
-  const canProceed = noPreferences || ingredients.length > 0;
+  const canProceed = ingredients.length > 0;
 
   const handleNext = () => {
     if (!canProceed) return;

--- a/src/app/(auth)/onboarding/characteristic/page.tsx
+++ b/src/app/(auth)/onboarding/characteristic/page.tsx
@@ -26,9 +26,6 @@ export default function AllergiesPage() {
 
   const handleNoPreferencesChange = (value: boolean) => {
     setNoPreferences(value);
-    if (value) {
-      router.push("/onboarding/characteristic/food-types");
-    }
   };
 
   return (

--- a/src/components/onboarding/characteristic/no-preferences-field.tsx
+++ b/src/components/onboarding/characteristic/no-preferences-field.tsx
@@ -2,7 +2,7 @@ import { cn } from "@/src/lib/utils";
 
 interface NoPreferencesFieldProps {
   value: boolean;
-  onChange: (value: boolean) => void;
+  onChange?: (value: boolean) => void;
 }
 
 export function NoPreferencesField({
@@ -12,7 +12,7 @@ export function NoPreferencesField({
   return (
     <button
       type="button"
-      onClick={() => onChange(!value)}
+      onClick={() => onChange?.(!value)}
       className={cn(
         "flex h-16 w-full items-center justify-center rounded-lg text-base font-semibold transition-colors",
         value


### PR DESCRIPTION
## 관련 이슈
#57

## 작업 내용

개인 특성 단계에서 “해당 없음” 선택 시 자동으로 다음 버튼이 활성화되던 문제를 수정했다. 선택 값이 존재하는 경우에만 다음 단계로 진행할 수 있도록 흐름을 정리했다.

### 기존 코드 
``` typescript
const { noPreferences, foodTypes, setFoodTypes } = useOnboardingStore();
const canProceed = noPreferences || ingredients.length > 0;
```
onboarding/characteristic/ingredients, onboarding/characteristic/food-types 페이지에서 “해당 없음”을 선택하면 실제 선택 없이도 <다음> 버튼이 활성화되는 문제가 있었다. canProceed 조건에 noPreferences가 포함되어 있어 사용자가 명시적인 선택을 하지 않아도 다음 단계로 이동 가능했다. 일부 단계에서는 “해당 없음” 클릭 시 자동으로 다음 화면으로 이동하여, 사용자 의도와 다른 흐름이 발생할 수 있었다.

### 개선 코드 
``` typescript
const { foodTypes, setFoodTypes } = useOnboardingStore();
const canProceed = ingredients.length > 0;
```
canProceed 조건을 선택한 value가 존재하는 경우에만 true가 되도록 수정했다. Food-types / Ingredients 페이지에서 canProceed 조건에서 noPreferences를 제외했다. 특성 메인 페이지에서 “해당 없음” 클릭 시 자동 라우팅을 제거하고, <다음> 버튼을 눌러야만 이동하도록 UX 흐름을 정리했다.