### PR TITLE
🐛 fix: 클라이언트에서 서버 액션 호출하여 쿠키 설정 에러 해결

### DIFF
--- a/src/app/(auth)/kakao/callback/kakao-callback-content.tsx
+++ b/src/app/(auth)/kakao/callback/kakao-callback-content.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { LoaderCircle } from "lucide-react";
+import { EmptyState } from "@/src/components/ui/empty-state";
+import { PageHeader } from "@/src/components/ui/page-header";
+import { processKakaoOAuth } from "@/src/lib/actions/auth";
+import { KakaoCallbackError } from "./kakao-callback-error";
+
+interface KakaoCallbackContentProps {
+  code: string;
+}
+
+export function KakaoCallbackContent({ code }: KakaoCallbackContentProps) {
+  const router = useRouter();
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const run = async () => {
+      const result = await processKakaoOAuth(code);
+
+      if (!result.success) {
+        setError(result.error);
+        return;
+      }
+
+      switch (result.onboardingStep) {
+        case "BASIC":
+          router.replace("/onboarding/basic");
+          return;
+        case "CHARACTERISTIC":
+          router.replace("/onboarding/characteristic");
+          return;
+        case "DONE":
+          router.replace("/");
+          return;
+      }
+    };
+
+    run();
+  }, [code, router]);
+
+  if (error) {
+    return <KakaoCallbackError message={error} />;
+  }
+
+  return (
+    <div className="mx-auto min-h-screen w-full max-w-[430px] bg-background px-4 sm:px-0">
+      <PageHeader
+        title="카카오 로그인 처리"
+        subtitle="인가 코드를 확인 중입니다."
+      />
+
+      <main className="flex flex-1 flex-col px-5 pb-10 pt-6">
+        <EmptyState
+          icon={LoaderCircle}
+          title="로그인 처리 중"
+          description="카카오 로그인 정보를 확인하고 있어요."
+          className="py-10"
+        />
+      </main>
+    </div>
+  );
+}

--- a/src/app/(auth)/kakao/callback/page.tsx
+++ b/src/app/(auth)/kakao/callback/page.tsx
@@ -1,5 +1,4 @@
-import { redirect } from "next/navigation";
-import { processKakaoOAuth } from "@/src/lib/actions/auth";
+import { KakaoCallbackContent } from "./kakao-callback-content";
 import { KakaoCallbackError } from "./kakao-callback-error";
 
 interface KakaoCallbackPageProps {
@@ -29,20 +28,6 @@ export default async function KakaoCallbackPage({
     return <KakaoCallbackError message="인가코드가 전달되지 않았습니다." />;
   }
 
-  // 3. 백엔드 인증 처리
-  const result = await processKakaoOAuth(code);
-
-  if (!result.success) {
-    return <KakaoCallbackError message={result.error} />;
-  }
-
-  // 4. 온보딩 상태에 따른 리디렉션
-  switch (result.onboardingStep) {
-    case "BASIC":
-      redirect("/onboarding/basic");
-    case "CHARACTERISTIC":
-      redirect("/onboarding/characteristic");
-    case "DONE":
-      redirect("/");
-  }
+  // 3. 클라이언트 컴포넌트에서 서버 액션 호출
+  return <KakaoCallbackContent code={code} />;
 }


### PR DESCRIPTION
#75 

KaKaoAuthContent가 서버 컴포넌트로 정의되어있어서 클라이언트 컴포넌트로 바꿔주고, 서버 액션을 추가해줬다. 

`cookies can only be modified in a server action or route handler`