### PR TITLE
fix: 로그인 리다이렉트 시 가드 우회 및 토큰 정리 개선

### DIFF
--- a/src/components/guards/RouteGuard.tsx
+++ b/src/components/guards/RouteGuard.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, ReactNode } from 'react';
-import { useRouter, usePathname } from 'next/navigation';
+import { useRouter, usePathname, useSearchParams } from 'next/navigation';
 import { useUserStore } from '@/src/stores/user-store';
 import { getRedirectPath, isGuardBypassRoute } from '@/src/lib/route-guard/route-access';
 
@@ -19,7 +19,6 @@ function getAndClearReturnUrl(): string | null {
 
   if (!returnUrl) return null;
 
-  // 보안: 내부 URL만 허용 (외부 URL 방지)
   if (!returnUrl.startsWith('/')) return null;
 
   return returnUrl;
@@ -28,16 +27,18 @@ function getAndClearReturnUrl(): string | null {
 export function RouteGuard({ children }: RouteGuardProps) {
   const router = useRouter();
   const pathname = usePathname();
+  const searchParams = useSearchParams();
   const { user, isInitialized } = useUserStore();
 
+  const isProxyRedirectedLogin = pathname === '/login' && searchParams.has('redirect');
+
   useEffect(() => {
-    // 초기화 전이면 대기
     if (!isInitialized) return;
 
-    // 예외 경로는 Guard 검사 건너뜀
     if (isGuardBypassRoute(pathname)) return;
 
-    // DONE 상태이고 returnUrl이 있으면 해당 URL로 이동
+    if (isProxyRedirectedLogin) return;
+
     if (user?.onboardingStep === 'DONE') {
       const returnUrl = getAndClearReturnUrl();
       if (returnUrl && pathname !== returnUrl) {
@@ -46,24 +47,24 @@ export function RouteGuard({ children }: RouteGuardProps) {
       }
     }
 
-    // 리다이렉트가 필요한지 확인
     const redirectPath = getRedirectPath(pathname, user);
     if (redirectPath) {
       router.replace(redirectPath);
     }
-  }, [pathname, user, isInitialized, router]);
+  }, [pathname, user, isInitialized, router, isProxyRedirectedLogin]);
 
-  // 초기화 전이면 로딩 표시
   if (!isInitialized) {
     return <RouteGuardSkeleton />;
   }
 
-  // 예외 경로는 즉시 렌더링
   if (isGuardBypassRoute(pathname)) {
     return <>{children}</>;
   }
 
-  // 리다이렉트가 필요하면 로딩 표시
+  if (isProxyRedirectedLogin) {
+    return <>{children}</>;
+  }
+
   const redirectPath = getRedirectPath(pathname, user);
   if (redirectPath) {
     return <RouteGuardSkeleton />;

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -28,14 +28,14 @@ export async function proxy(request: NextRequest) {
   const accessToken = request.cookies.get('access_token')?.value;
   const refreshToken = request.cookies.get('refresh_token')?.value;
 
-  // refresh_token도 없으면 로그인 페이지로
   if (!refreshToken) {
     const loginUrl = new URL(ROUTES.LOGIN, request.nextUrl.origin);
     loginUrl.searchParams.set("redirect", `${pathname}${search}`);
-    return NextResponse.redirect(loginUrl);
+    const response = NextResponse.redirect(loginUrl);
+    response.cookies.delete('access_token');
+    return response;
   }
 
-  // access_token이 없고 refresh_token이 있으면 갱신 시도
   if (!accessToken && refreshToken) {
     const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL;
 
@@ -51,14 +51,12 @@ export async function proxy(request: NextRequest) {
         const setCookieHeader = reissueResponse.headers.get("set-cookie");
 
         if (setCookieHeader) {
-          // Set-Cookie에서 모든 쿠키 파싱
           const cookieStrings = setCookieHeader.split(/,(?=\s*\w+=)/);
           const requestHeaders = new Headers(request.headers);
 
           for (const cookieString of cookieStrings) {
             const parsed = parseCookie(cookieString.trim());
             if (parsed) {
-              // 각 쿠키를 헤더로 전달
               requestHeaders.set(parsed.name, parsed.value);
             }
           }
@@ -67,7 +65,6 @@ export async function proxy(request: NextRequest) {
             request: { headers: requestHeaders },
           });
 
-          // 브라우저에 쿠키 설정 (다음 요청부터 사용)
           response.headers.set("Set-Cookie", setCookieHeader);
 
           return response;


### PR DESCRIPTION
## 관련 이슈 
#270

## 상세
- 로그인 진입 시 `RouteGuard`가 `redirect` 쿼리와 충돌하지 않도록 예외 처리
- `refresh_token` 부재 시 로그인 리다이렉트와 함께 `access_token`을 정리