### PR TITLE
fix: 인증 리다이렉트 안정화 및 Suspense 렌더링 경계 보강

### DIFF
--- a/src/app/(auth)/kakao/callback/page.tsx
+++ b/src/app/(auth)/kakao/callback/page.tsx
@@ -1,22 +1,21 @@
+import { Suspense } from "react";
 import { KakaoCallbackContent } from "./kakao-callback-content";
 import { KakaoCallbackError } from "./kakao-callback-error";
 
 interface KakaoCallbackPageProps {
-  searchParams: Promise<{
+  searchParams: {
     code?: string;
     error?: string;
     error_description?: string;
     state?: string;
-  }>;
+  };
 }
 
 export default async function KakaoCallbackPage({
   searchParams,
 }: KakaoCallbackPageProps) {
-  const params = await searchParams;
-  const { code, error, error_description, state } = params;
+  const { code, error, error_description, state } = searchParams;
 
-  // 1. OAuth 자체 에러
   if (error) {
     const message = error_description
       ? `${error}: ${error_description}`
@@ -24,11 +23,13 @@ export default async function KakaoCallbackPage({
     return <KakaoCallbackError message={message} />;
   }
 
-  // 2. 인가 코드 없음
   if (!code) {
     return <KakaoCallbackError message="인가코드가 전달되지 않았습니다." />;
   }
 
-  // 3. 클라이언트 컴포넌트에서 서버 액션 호출
-  return <KakaoCallbackContent code={code} redirectPath={state} />;
+  return (
+    <Suspense fallback={<div>로그인 처리 중...</div>}>
+      <KakaoCallbackContent code={code} redirectPath={state} />
+    </Suspense>
+  );
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import type { Viewport } from "next";
+import { Suspense } from "react";
 import "./globals.css";
 import { Toaster } from "@/src/components/ui/sonner";
 import localFont from 'next/font/local';
@@ -42,9 +43,11 @@ export default function RootLayout({
             <QueryProvider>
               <UserProvider>
                 <WebPushProvider>
-                  <RouteGuard>
-                    {children}
-                  </RouteGuard>
+                  <Suspense>
+                    <RouteGuard>
+                      {children}
+                    </RouteGuard>
+                  </Suspense>
                 </WebPushProvider>
               </UserProvider>
             </QueryProvider>


### PR DESCRIPTION
 ## 상세
- 카카오 콜백과 전역 가드의 Suspense 경계 추가
- 콜백 처리 및 전역 RouteGuard`에 Suspense 경계를 추가