### PR TITLE
🐛 fix: 채팅 메시지가 영어 일 때 메시지 아이템이 숨겨지는 문제 해결

### DIFF
--- a/src/components/lightning/chat/chat-message-item.tsx
+++ b/src/components/lightning/chat/chat-message-item.tsx
@@ -51,7 +51,7 @@ export function ChatMessageItem({
           </div>
         )}
 
-        <div className="max-w-[78%] space-y-1">
+        <div className="max-w-[78%] min-w-0 space-y-1">
           {!isMine && (
             <p className="px-1 text-xs text-muted-foreground">
               {senderLabel}
@@ -74,8 +74,8 @@ export function ChatMessageItem({
             <p
               className={
                 isMine
-                  ? "break-words rounded-2xl rounded-br-md bg-primary px-4 py-2.5 text-base leading-6 text-primary-foreground"
-                  : "break-words rounded-2xl rounded-bl-md bg-background px-4 py-2.5 text-base leading-6 text-foreground shadow-xs"
+                  ? "max-w-full break-all rounded-2xl rounded-br-md bg-primary px-4 py-2.5 text-base leading-6 text-primary-foreground"
+                  : "max-w-full break-all break-words rounded-2xl rounded-bl-md bg-background px-4 py-2.5 text-base leading-6 text-foreground shadow-xs"
               }
             >
               {message.content}


### PR DESCRIPTION
## 관련 이슈 
#284 

## 상세
- 메시지 컨테이너에 `min-w-0`을 추가해 flex 환경에서 내용 폭 계산이 정상 동작하도록 정리
- 말풍선 텍스트 영역에 `max-w-full`, `break-all`을 적용해 긴 영문 문자열 줄바꿈 개선