### PR TITLE
refactor: 소켓 연결 handshake와 복구 흐름 안정성 개선

### DIFF
--- a/src/lib/websocket/socket-manager.ts
+++ b/src/lib/websocket/socket-manager.ts
@@ -32,6 +32,7 @@ export class SocketManager {
   private registry = new Map<SubscriptionKey, SubscriptionDef>();
   private deactivating: Promise<void> | null = null;
   private recovering: Promise<void> | null = null;
+  private explicitDisconnect = false;
   private tokenReissuePromise: Promise<string | null> | null = null;
   private reconnectFailureCount = 0;
   private readonly maxReconnectWithCurrentToken = 1;
@@ -133,6 +134,8 @@ export class SocketManager {
           if (!handshakeDone) {
             handshakeDone = true;
             reject(new Error(`WebSocket closed before handshake: code=${evt.code}`));
+          } else if (!this.explicitDisconnect) {
+            void this.handleSocketError("ws-close", evt);
           }
         },
         onStompError: (frame) => {
@@ -179,10 +182,12 @@ export class SocketManager {
 
     const p = (async () => {
       try {
+        this.explicitDisconnect = true;
         await client.deactivate();
       } catch (error) {
         this.log("disconnect error", error);
       } finally {
+        this.explicitDisconnect = false;
         this.clearSubscriptionHandles();
         this.client = null;
         this.log("disconnect done");


### PR DESCRIPTION
## 관련 이슈 
#349 

## 상세 
- 소켓 매니저에서 복구 진행을 single flight로 처리하여 복구 진행을 하나의 요청에서 실행하도록 처리 
- 소켓 메니저에서 handshake 완료 전 연결 상태를 Promise로 관리하고, generation 불일치 시 이전 연결 시도를 취소하는 로직 추가
- 소켓 연결 종료 시 사용자 명시 종료가 아닌 경우 복구 대상으로 처리